### PR TITLE
Set the sysconfdir to /etc

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,6 @@
 set -e
 set -x
 
-CFLAGS="-O2 ${CFLAGS}" CXXFLAGS="-O2 ${CXXFLAGS}" ./configure --prefix=$PREFIX
+CFLAGS="-O2 ${CFLAGS}" CXXFLAGS="-O2 ${CXXFLAGS}" ./configure --sysconfdir=/etc --prefix=$PREFIX
 make -j${CPU_COUNT}
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
Not setting `--sysconfdir=/etc` results in using the default location of `{prefix}/etc`. This causes the system odbcinst.ini file not to be located. Rather it will stall at `looking for entry named [MyODBCDriver] in /path/to/conda/env/etc/odbcinst.ini`.

This change mirrors exactly what the [anaconda recipe](https://github.com/ContinuumIO/anaconda-recipes/blob/master/unixodbc/build.sh) does with `./configure`.